### PR TITLE
feature/mx-1648 fix endpoint serializing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- BREAKING: use `items` instead of `results` in paged wiki response
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fix endpoint serializing not working with `mex.common.types`
+
 ### Security
 
 ## [0.15.0] - 2024-06-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 
 - BREAKING: use `items` instead of `results` in paged wiki response
+- downgrade query logging to log level `debug`
 
 ### Deprecated
 

--- a/mex/backend/auxiliary/models.py
+++ b/mex/backend/auxiliary/models.py
@@ -2,13 +2,11 @@ from typing import Generic, TypeVar
 
 from pydantic import BaseModel
 
-T = TypeVar("T")
+ResponseItemT = TypeVar("ResponseItemT", bound=BaseModel)
 
 
-class PagedResponseSchema(BaseModel, Generic[T]):
-    """Response schema for any paged API."""
+class PagedAuxiliaryResponse(BaseModel, Generic[ResponseItemT]):
+    """Response model for any paged aux API."""
 
+    items: list[ResponseItemT]
     total: int
-    offset: int
-    limit: int
-    results: list[T]

--- a/mex/backend/extracted/main.py
+++ b/mex/backend/extracted/main.py
@@ -2,9 +2,11 @@ from collections.abc import Sequence
 from typing import Annotated
 
 from fastapi import APIRouter, Query
+from fastapi.responses import JSONResponse
 
 from mex.backend.extracted.models import ExtractedItemSearchResponse
 from mex.backend.graph.connector import GraphConnector
+from mex.backend.transform import to_primitive
 from mex.backend.types import ExtractedType
 from mex.common.types import Identifier
 
@@ -30,4 +32,5 @@ def search_extracted_items(
         skip,
         limit,
     )
-    return ExtractedItemSearchResponse.model_validate(result.one())
+    response = ExtractedItemSearchResponse.model_validate(result.one())
+    return JSONResponse(to_primitive(response))  # type: ignore[return-value]

--- a/mex/backend/extracted/models.py
+++ b/mex/backend/extracted/models.py
@@ -8,5 +8,5 @@ from mex.common.models import AnyExtractedModel, BaseModel
 class ExtractedItemSearchResponse(BaseModel):
     """Response body for the extracted item search endpoint."""
 
-    total: int
     items: Annotated[list[AnyExtractedModel], Field(discriminator="entityType")]
+    total: int

--- a/mex/backend/graph/connector.py
+++ b/mex/backend/graph/connector.py
@@ -150,9 +150,9 @@ class GraphConnector(BaseConnector):
             logger.error("\n%s\n%s", message, error)
             raise
         if counters := result.get_update_counters():
-            logger.info("\n%s\n%s", message, json.dumps(counters, indent=4))
+            logger.debug("\n%s\n%s", message, json.dumps(counters, indent=4))
         else:
-            logger.info("\n%s", message)
+            logger.debug("\n%s", message)
         return result
 
     def fetch_extracted_data(

--- a/mex/backend/identity/models.py
+++ b/mex/backend/identity/models.py
@@ -13,5 +13,5 @@ class IdentityAssignRequest(BaseModel):
 class IdentityFetchResponse(BaseModel):
     """Response body for identity fetch requests."""
 
-    items: list[Identity] = []
-    total: int = 0
+    items: list[Identity]
+    total: int

--- a/mex/backend/ingest/main.py
+++ b/mex/backend/ingest/main.py
@@ -1,7 +1,9 @@
 from fastapi import APIRouter
+from fastapi.responses import JSONResponse
 
 from mex.backend.graph.connector import GraphConnector
 from mex.backend.ingest.models import BulkIngestRequest, BulkIngestResponse
+from mex.backend.transform import to_primitive
 
 router = APIRouter()
 
@@ -12,4 +14,5 @@ def ingest_extracted_items(request: BulkIngestRequest) -> BulkIngestResponse:
     connector = GraphConnector.get()
     models = request.get_all()
     identifiers = connector.ingest(models)
-    return BulkIngestResponse(identifiers=identifiers)
+    response = BulkIngestResponse(identifiers=identifiers)
+    return JSONResponse(to_primitive(response))  # type: ignore[return-value]

--- a/mex/backend/ingest/main.py
+++ b/mex/backend/ingest/main.py
@@ -15,4 +15,4 @@ def ingest_extracted_items(request: BulkIngestRequest) -> BulkIngestResponse:
     models = request.get_all()
     identifiers = connector.ingest(models)
     response = BulkIngestResponse(identifiers=identifiers)
-    return JSONResponse(to_primitive(response))  # type: ignore[return-value]
+    return JSONResponse(to_primitive(response), 201)  # type: ignore[return-value]

--- a/mex/backend/merged/main.py
+++ b/mex/backend/merged/main.py
@@ -2,9 +2,11 @@ from collections.abc import Sequence
 from typing import Annotated
 
 from fastapi import APIRouter, Query
+from fastapi.responses import JSONResponse
 
 from mex.backend.graph.connector import GraphConnector
 from mex.backend.merged.models import MergedItemSearchResponse
+from mex.backend.transform import to_primitive
 from mex.backend.types import MergedType, UnprefixedType
 from mex.common.transform import ensure_prefix
 from mex.common.types import Identifier
@@ -46,4 +48,5 @@ def search_merged_items_facade(
         item["identifier"] = item.pop("stableTargetId")
         item["entityType"] = item["entityType"].replace("Extracted", "Merged")
 
-    return MergedItemSearchResponse.model_validate(result.one())
+    response = MergedItemSearchResponse.model_validate(result.one())
+    return JSONResponse(to_primitive(response))  # type: ignore[return-value]

--- a/mex/backend/merged/models.py
+++ b/mex/backend/merged/models.py
@@ -8,5 +8,5 @@ from mex.common.models import AnyMergedModel, BaseModel
 class MergedItemSearchResponse(BaseModel):
     """Response body for the merged item search endpoint."""
 
-    total: int
     items: Annotated[list[AnyMergedModel], Field(discriminator="entityType")]
+    total: int

--- a/mex/backend/rules/main.py
+++ b/mex/backend/rules/main.py
@@ -12,6 +12,5 @@ router = APIRouter()
 def create_rule(rule: AnyRuleModel) -> AnyRuleModel:
     """Create a new rule."""
     connector = GraphConnector.get()
-    return JSONResponse(  # type: ignore[return-value]
-        to_primitive(connector.create_rule(rule)),
-    )
+    response = connector.create_rule(rule)
+    return JSONResponse(to_primitive(response))  # type: ignore[return-value]

--- a/tests/auxiliary/conftest.py
+++ b/tests/auxiliary/conftest.py
@@ -17,14 +17,14 @@ from mex.common.wikidata.models.organization import WikidataOrganization
 TEST_DATA_DIR = Path(__file__).parent / "test_data"
 
 
-@pytest.fixture
+@pytest.fixture()
 def wikidata_organization_raw() -> dict[str, Any]:
     """Return a raw wikidata organization."""
     with open(TEST_DATA_DIR / "wikidata_organization_raw.json") as fh:
         return json.load(fh)
 
 
-@pytest.fixture
+@pytest.fixture()
 def wikidata_organization(
     wikidata_organization_raw: dict[str, Any],
 ) -> WikidataOrganization:
@@ -32,7 +32,7 @@ def wikidata_organization(
     return WikidataOrganization.model_validate(wikidata_organization_raw)
 
 
-@pytest.fixture
+@pytest.fixture()
 def mocked_wikidata(
     monkeypatch: MonkeyPatch, wikidata_organization_raw: dict[str, Any]
 ) -> None:

--- a/tests/auxiliary/test_wikidata.py
+++ b/tests/auxiliary/test_wikidata.py
@@ -9,9 +9,7 @@ from mex.common.models import (
 from mex.common.types import Text
 
 
-@pytest.mark.usefixtures(
-    "mocked_wikidata",
-)
+@pytest.mark.usefixtures("mocked_wikidata")
 def test_search_organization_in_wikidata_mocked(
     client_with_api_key_read_permission: TestClient, monkeypatch: MonkeyPatch
 ) -> None:
@@ -39,10 +37,9 @@ def test_search_organization_in_wikidata_mocked(
 
     assert organizations["total"] == expected_total
     assert (
-        organizations["results"][0]["identifierInPrimarySource"]
+        organizations["items"][0]["identifierInPrimarySource"]
         == expected_organization_identifier
     )
     assert (
-        organizations["results"][0]["officialName"]
-        == expected_organization_official_name
+        organizations["items"][0]["officialName"] == expected_organization_official_name
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,28 +56,28 @@ def skip_integration_test_in_ci(is_integration_test: bool) -> None:
     """Overwrite fixture from plugin to not skip integration tests in ci."""
 
 
-@pytest.fixture
+@pytest.fixture()
 def client() -> TestClient:
     """Return a fastAPI test client initialized with our app."""
     with TestClient(app, raise_server_exceptions=False) as test_client:
         return test_client
 
 
-@pytest.fixture
+@pytest.fixture()
 def client_with_api_key_write_permission(client: TestClient) -> TestClient:
     """Return a fastAPI test client with write permission initialized with our app."""
     client.headers.update({"X-API-Key": "write_key"})
     return client
 
 
-@pytest.fixture
+@pytest.fixture()
 def client_with_api_key_read_permission(client: TestClient) -> TestClient:
     """Return a fastAPI test client with read permission granted by API key."""
     client.headers.update({"X-API-Key": "read_key"})
     return client
 
 
-@pytest.fixture
+@pytest.fixture()
 def client_with_basic_auth_read_permission(client: TestClient) -> TestClient:
     """Return a fastAPI test client with read permission granted by basic auth."""
     client.headers.update(
@@ -86,7 +86,7 @@ def client_with_basic_auth_read_permission(client: TestClient) -> TestClient:
     return client
 
 
-@pytest.fixture
+@pytest.fixture()
 def client_with_basic_auth_write_permission(client: TestClient) -> TestClient:
     """Return a fastAPI test client with write permission granted by basic auth."""
     client.headers.update(
@@ -121,7 +121,7 @@ class MockedGraph:
         return self.run.call_args_list
 
 
-@pytest.fixture
+@pytest.fixture()
 def mocked_graph(monkeypatch: MonkeyPatch) -> MockedGraph:
     """Mock the graph connector and return the mocked `run` for easy manipulation."""
     records: list[Any] = []
@@ -183,7 +183,7 @@ def isolate_graph_database(
                 driver.execute_query(f"DROP INDEX {row['name']};")
 
 
-@pytest.fixture
+@pytest.fixture()
 def dummy_data() -> list[AnyExtractedModel]:
     """Create a set of interlinked dummy data."""
     primary_source_1 = ExtractedPrimarySource(
@@ -237,14 +237,14 @@ def dummy_data() -> list[AnyExtractedModel]:
     ]
 
 
-@pytest.fixture
+@pytest.fixture()
 def load_dummy_data(dummy_data: list[AnyExtractedModel]) -> list[AnyExtractedModel]:
     """Ingest dummy data into the graph."""
     GraphConnector.get().ingest(dummy_data)
     return dummy_data
 
 
-@pytest.fixture
+@pytest.fixture()
 def additive_organizational_unit(
     dummy_data: list[AnyExtractedModel],
 ) -> AdditiveOrganizationalUnit:

--- a/tests/graph/test_connector.py
+++ b/tests/graph/test_connector.py
@@ -18,7 +18,7 @@ from mex.common.types import Identifier
 from tests.conftest import MockedGraph
 
 
-@pytest.fixture
+@pytest.fixture()
 def mocked_query_builder(monkeypatch: MonkeyPatch) -> None:
     def __getattr__(_: QueryBuilder, query: str) -> Callable[..., str]:
         return lambda **parameters: format_str(

--- a/tests/graph/test_models.py
+++ b/tests/graph/test_models.py
@@ -16,7 +16,7 @@ from mex.backend.graph.models import Result
 from mex.common.testing import Joker
 
 
-@pytest.fixture
+@pytest.fixture()
 def summary() -> Mock:
     class SummaryCounters:
         def __init__(self) -> None:
@@ -27,7 +27,7 @@ def summary() -> Mock:
     return Mock(spec=Neo4jResultSummary, counters=SummaryCounters())
 
 
-@pytest.fixture
+@pytest.fixture()
 def multiple_results(summary: Mock) -> Mock:
     records = [
         Mock(spec=Neo4jRecord, data=MagicMock(return_value={"num": 40})),
@@ -39,14 +39,14 @@ def multiple_results(summary: Mock) -> Mock:
     )
 
 
-@pytest.fixture
+@pytest.fixture()
 def no_result(summary: Mock) -> Mock:
     return Mock(
         spec=Neo4jResult, to_eager_result=MagicMock(return_value=([], summary, []))
     )
 
 
-@pytest.fixture
+@pytest.fixture()
 def single_result(summary: Mock) -> Mock:
     records = [
         Mock(

--- a/tests/graph/test_query.py
+++ b/tests/graph/test_query.py
@@ -4,7 +4,7 @@ from pydantic import ValidationError
 from mex.backend.graph.query import QueryBuilder, render_constraints
 
 
-@pytest.fixture
+@pytest.fixture()
 def query_builder() -> QueryBuilder:
     builder = QueryBuilder.get()
     builder._env.globals.update(

--- a/tests/ingest/test_main.py
+++ b/tests/ingest/test_main.py
@@ -11,7 +11,7 @@ from tests.conftest import MockedGraph
 Payload = dict[str, list[dict[str, Any]]]
 
 
-@pytest.fixture
+@pytest.fixture()
 def post_payload(dummy_data: list[AnyExtractedModel]) -> Payload:
     payload = defaultdict(list)
     for model in dummy_data:


### PR DESCRIPTION
### Changes

- BREAKING: use `items` instead of `results` in paged wiki response
- downgrade query logging to log level `debug`

### Fixed

- fix endpoint serializing not working with `mex.common.types`
