### PR TITLE
Bump cookiecutter template to 4ba5ad

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "b0a2056a104f39cd18e6b395a27d18473caa73d7",
+  "commit": "4ba5ad58c9f60646ce8927273829613905f3696e",
   "checkout": null,
   "context": {
     "cookiecutter": {

--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run renovatebot
-        uses: renovatebot/github-action@v40.3.6
+        uses: renovatebot/github-action@v41.0.2
         env:
           RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           RENOVATE_REPOSITORIES: "robert-koch-institut/mex-backend"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ cruft==2.15.0
 mex-release==0.3.0
 pdm==2.20.1
 pre-commit==4.0.1
-wheel==0.44.0
+wheel==0.45.0


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/4ba5ad
