### PR TITLE
Bump cookiecutter template to a4f25a

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "4ba5ad58c9f60646ce8927273829613905f3696e",
+  "commit": "a4f25ab84f9e485ad77eb03663a9cf486f7a5826",
   "checkout": null,
   "context": {
     "cookiecutter": {


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/a4f25a
