### PR TITLE
feature/update mex-common to 0.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- update mex-common to 0.48.0
+
 ### Deprecated
 
 ### Removed
+
+- remove backend settings that were just duplicating common settings
+- removed BackendIdentityProvider enum, because it is now included in common
 
 ### Fixed
 

--- a/mex/backend/__init__.py
+++ b/mex/backend/__init__.py
@@ -3,7 +3,7 @@ from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
 from mex.backend.identity.provider import GraphIdentityProvider
-from mex.backend.types import BackendIdentityProvider
 from mex.common.identity.registry import register_provider
+from mex.common.types import IdentityProvider
 
-register_provider(BackendIdentityProvider.GRAPH, GraphIdentityProvider)
+register_provider(IdentityProvider.GRAPH, GraphIdentityProvider)

--- a/mex/backend/settings.py
+++ b/mex/backend/settings.py
@@ -1,26 +1,12 @@
 from pydantic import Field, SecretStr
 
-from mex.backend.types import APIKeyDatabase, APIUserDatabase, BackendIdentityProvider
+from mex.backend.types import APIKeyDatabase, APIUserDatabase
 from mex.common.settings import BaseSettings
-from mex.common.types import IdentityProvider, Sink
 
 
 class BackendSettings(BaseSettings):
     """Settings definition for the backend server."""
 
-    debug: bool = Field(
-        False,
-        alias="reload",
-        description="Enable debug mode.",
-        validation_alias="MEX_DEBUG",
-    )
-    sink: list[Sink] = Field(
-        [Sink.GRAPH],
-        description=(
-            "Where to send ingested data. Defaults to writing to the graph db."
-        ),
-        validation_alias="MEX_SINK",
-    )
     backend_host: str = Field(
         "localhost",
         min_length=1,
@@ -70,8 +56,3 @@ class BackendSettings(BaseSettings):
         description="Database of users.",
         validation_alias="MEX_BACKEND_API_USER_DATABASE",
     )
-    identity_provider: IdentityProvider | BackendIdentityProvider = Field(
-        IdentityProvider.MEMORY,
-        description="Provider to assign stableTargetIds to new model instances.",
-        validation_alias="MEX_IDENTITY_PROVIDER",
-    )  # type: ignore[assignment]

--- a/mex/backend/types.py
+++ b/mex/backend/types.py
@@ -43,12 +43,6 @@ class APIUserDatabase(BaseModel):
     write: dict[str, APIUserPassword] = {}
 
 
-class BackendIdentityProvider(Enum):
-    """Identity providers implemented by mex-backend."""
-
-    GRAPH = "graph"
-
-
 class DynamicStrEnum(EnumMeta):
     """Meta class to dynamically populate the an enumeration from a list of strings."""
 

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:2fda142393da18905265cc467d58d9359e042d447bf712c97d61d34d9cff00c3"
+content_hash = "sha256:717f8795a04248dd21fc05c338626616a17a140cf56dc29afefd5cf08ae369a4"
 
 [[metadata.targets]]
 requires_python = "==3.11.*"
@@ -539,11 +539,11 @@ files = [
 
 [[package]]
 name = "mex-common"
-version = "0.47.1"
+version = "0.48.0"
 requires_python = ">=3.11,<3.13"
 git = "https://github.com/robert-koch-institut/mex-common.git"
-ref = "0.47.1"
-revision = "2d72df349a5404ca597296aac824da9b33aa62b3"
+ref = "0.48.0"
+revision = "9a917770bf36f04e5fe62cdb7b0ca36ee68d143c"
 summary = "Common library for MEx python projects."
 groups = ["default"]
 marker = "python_version == \"3.11\""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "fastapi>=0.115,<1",
     "httpx>=0.27,<1",
     "jinja2>=3,<4",
-    "mex-common @ git+https://github.com/robert-koch-institut/mex-common.git@0.47.1",
+    "mex-common @ git+https://github.com/robert-koch-institut/mex-common.git@0.48.0",
     "neo4j>=5,<6",
     "pydantic>=2,<3",
     "starlette>=0.41,<1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from mex.backend.identity.provider import GraphIdentityProvider
 from mex.backend.main import app
 from mex.backend.rules.helpers import create_and_get_rule_set
 from mex.backend.settings import BackendSettings
-from mex.backend.types import APIKeyDatabase, APIUserDatabase, BackendIdentityProvider
+from mex.backend.types import APIKeyDatabase, APIUserDatabase
 from mex.common.connector import CONNECTOR_STORE
 from mex.common.models import (
     MEX_PRIMARY_SOURCE_STABLE_TARGET_ID,
@@ -186,9 +186,7 @@ def set_identity_provider(is_integration_test: bool, monkeypatch: MonkeyPatch) -
     for settings in (BaseSettings.get(), BackendSettings.get()):
         if is_integration_test:
             monkeypatch.setitem(settings.model_config, "validate_assignment", False)
-            monkeypatch.setattr(
-                settings, "identity_provider", BackendIdentityProvider.GRAPH
-            )
+            monkeypatch.setattr(settings, "identity_provider", IdentityProvider.GRAPH)
         else:
             monkeypatch.setattr(settings, "identity_provider", IdentityProvider.MEMORY)
 


### PR DESCRIPTION
## Changed
- update mex-common to 0.48.0

## Removed
- remove backend settings that were just duplicating common settings
- removed BackendIdentityProvider enum, because it is now included in common
