### PR TITLE
feature/mx-1678 full search text endpoint for orcid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- ORCID search endpoint in mex-backend
+  - endpoint returning orcid persons (tranformed to ExtractedPersons)
+  - full-text search query parameter `q` and pagination parameters `offset` and `limit`
+  - response body contains
+      - items: list[ExtractedPerson]  - the current "page" of search results
+      - total: int  - the total number of persons found for this request
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       - total: int  - the total number of persons found for this request
 
 ### Changes
-
+- bumped common dependency to 0.56.0
 ### Deprecated
 
 ### Removed

--- a/assets/raw-data/primary-sources/primary-sources.json
+++ b/assets/raw-data/primary-sources/primary-sources.json
@@ -34,5 +34,14 @@
                 "value": "Wikidata APIs"
             }
         ]
+    },
+    {
+        "identifier": "orcid",
+        "title": [
+            {
+                "language": "en",
+                "value": "Orcid"
+            }
+        ]
     }
 ]

--- a/mex/backend/auxiliary/orcid.py
+++ b/mex/backend/auxiliary/orcid.py
@@ -1,0 +1,47 @@
+from typing import Annotated
+
+from fastapi import APIRouter, HTTPException, Query
+
+from mex.backend.auxiliary.models import AuxiliarySearch
+from mex.common.exceptions import EmptySearchResultError, FoundMoreThanOneError
+from mex.common.models import (
+    ExtractedPerson,
+)
+from mex.common.orcid.extract import get_orcid_record_by_name
+from mex.common.orcid.transform import transform_orcid_person_to_mex_person
+
+router = APIRouter()
+
+
+@router.get("/orcid", tags=["editor"])
+def search_person_in_orcid(
+    q: Annotated[str, Query(min_length=1, max_length=1000)],
+    offset: Annotated[int, Query(ge=0, le=10e10)] = 0,
+    limit: Annotated[int, Query(ge=1, le=100)] = 10,
+) -> AuxiliarySearch[ExtractedPerson]:
+    """Search for persons in orcid by string.
+
+    Args:
+        q: The name of the person to be searched.
+        offset: The starting index for pagination
+        limit: The maximum number of results to return
+
+    Returns:
+        ExtractedPerson and the total count of persons found.
+    """
+    try:
+        found_persons = [get_orcid_record_by_name(given_and_family_names=q)]
+    except EmptySearchResultError as e:
+        raise HTTPException(
+            status_code=404, detail=f"No results found for '{q}'."
+        ) from e
+    except FoundMoreThanOneError as e:
+        raise HTTPException(
+            status_code=400, detail=f"Multiple persons found for '{q}'."
+        ) from e
+    total_results = len(found_persons)
+    paginated_persons = found_persons[offset : offset + limit]
+    extracted_persons = [
+        transform_orcid_person_to_mex_person(person) for person in paginated_persons
+    ]
+    return AuxiliarySearch(items=extracted_persons, total=total_results)

--- a/mex/backend/auxiliary/orcid.py
+++ b/mex/backend/auxiliary/orcid.py
@@ -3,11 +3,13 @@ from typing import Annotated
 from fastapi import APIRouter, HTTPException, Query
 
 from mex.backend.auxiliary.models import AuxiliarySearch
-from mex.common.exceptions import EmptySearchResultError, FoundMoreThanOneError
+from mex.common.exceptions import EmptySearchResultError
 from mex.common.models import (
     ExtractedPerson,
 )
-from mex.common.orcid.extract import get_orcid_record_by_name
+from mex.common.orcid.extract import (
+    get_orcid_records_by_given_or_family_name,
+)
 from mex.common.orcid.transform import transform_orcid_person_to_mex_person
 
 router = APIRouter()
@@ -30,17 +32,16 @@ def search_person_in_orcid(
         ExtractedPerson and the total count of persons found.
     """
     try:
-        found_persons = [get_orcid_record_by_name(given_and_family_names=q)]
+        orcid_records = list(
+            get_orcid_records_by_given_or_family_name(given_and_family_names=q)
+        )
+
     except EmptySearchResultError as e:
         raise HTTPException(
             status_code=404, detail=f"No results found for '{q}'."
         ) from e
-    except FoundMoreThanOneError as e:
-        raise HTTPException(
-            status_code=400, detail=f"Multiple persons found for '{q}'."
-        ) from e
-    total_results = len(found_persons)
-    paginated_persons = found_persons[offset : offset + limit]
+    total_results = len(orcid_records)
+    paginated_persons = orcid_records[offset : offset + limit]
     extracted_persons = [
         transform_orcid_person_to_mex_person(person) for person in paginated_persons
     ]

--- a/mex/backend/main.py
+++ b/mex/backend/main.py
@@ -7,6 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic_core import SchemaError, ValidationError
 
 from mex.backend.auxiliary.ldap import router as ldap_router
+from mex.backend.auxiliary.orcid import router as orcid_router
 from mex.backend.auxiliary.wikidata import router as wikidata_router
 from mex.backend.exceptions import (
     BackendError,
@@ -58,6 +59,8 @@ router.include_router(preview_router, dependencies=[Depends(has_read_access)])
 router.include_router(rules_router, dependencies=[Depends(has_write_access)])
 router.include_router(wikidata_router, dependencies=[Depends(has_read_access)])
 router.include_router(ldap_router, dependencies=[Depends(has_read_access)])
+router.include_router(orcid_router, dependencies=[Depends(has_read_access)])
+
 router.include_router(system_router)
 
 app.include_router(router)

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:e1880211020db443b8cda1d069a79264d6c4cd25b737df1b9d4a7f6326e8897b"
+content_hash = "sha256:f84177a9688f1d09c695f162af8e73918c025f31dadc9790cc6dfcc71a4802d1"
 
 [[metadata.targets]]
 requires_python = "==3.11.*"
@@ -558,11 +558,11 @@ files = [
 
 [[package]]
 name = "mex-common"
-version = "0.54.1"
+version = "0.56.0"
 requires_python = ">=3.11,<3.13"
 git = "https://github.com/robert-koch-institut/mex-common.git"
-ref = "0.54.1"
-revision = "fb743618df7b98ca7360c1effa2c2fc8385ade17"
+ref = "0.56.0"
+revision = "5f5e04b6092c760228298310a2f8d976af372eef"
 summary = "Common library for MEx python projects."
 groups = ["default"]
 marker = "python_version == \"3.11\""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "black>=25,<26",
     "fastapi>=0.115,<1",
     "jinja2>=3,<4",
-    "mex-common @ git+https://github.com/robert-koch-institut/mex-common.git@0.54.1",
+    "mex-common @ git+https://github.com/robert-koch-institut/mex-common.git@0.56.0",
     "neo4j>=5,<6",
     "pydantic>=2,<3",
     "starlette>=0.41,<1",

--- a/tests/auxiliary/conftest.py
+++ b/tests/auxiliary/conftest.py
@@ -210,7 +210,7 @@ def mocked_orcid(
     monkeypatch.setattr(OrcidConnector, "build_query", build_query)
 
     def get_data_by_id(_self: OrcidConnector, orcid_id: str) -> dict[str, Any]:
-        if orcid_id == "0009-0004-3041-5706":
+        if orcid_id:
             return orcid_person_raw
         return None
 

--- a/tests/auxiliary/conftest.py
+++ b/tests/auxiliary/conftest.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import MagicMock, Mock
 from uuid import UUID
 
@@ -16,6 +17,7 @@ from mex.common.models import (
     ExtractedOrganizationalUnit,
     ExtractedPrimarySource,
 )
+from mex.common.orcid.connector import OrcidConnector
 from mex.common.wikidata.connector import (
     WikidataAPIConnector,
     WikidataQueryServiceConnector,
@@ -45,6 +47,30 @@ test_persons = [
         objectGUID=UUID(version=4, int=3),
         department="FG99",
     ),
+]
+
+test_person_orcid = [
+    {
+        "orcid-identifier": {
+            "uri": "https://orcid.org/0000-0002-1234-5678",
+            "path": "0000-0002-1234-5678",
+            "host": "orcid.org",
+        },
+        "person": {
+            "name": {
+                "given-names": {"value": "Jane"},
+                "family-name": {"value": "Doe"},
+                "visibility": "public",
+                "path": "0000-0002-1234-5678",
+            },
+            "emails": {
+                "email": [
+                    "jane.doe@example.com",
+                ],
+            },
+            "path": "/0000-0002-1234-5678/person",
+        },
+    }
 ]
 
 
@@ -128,3 +154,64 @@ def mocked_wikidata(monkeypatch: MonkeyPatch) -> None:
         "get_wikidata_item_details_by_id",
         get_wikidata_item_details_by_id,
     )
+
+
+@pytest.fixture
+def orcid_person_raw() -> dict[str, Any]:
+    """Return a raw orcid person."""
+    with open(TEST_DATA_DIR / "orcid_person_raw.json") as fh:
+        return cast(dict[str, Any], json.load(fh))
+
+
+@pytest.fixture
+def orcid_multiple_matches() -> dict[str, Any]:
+    """Return a raw orcid person."""
+    with open(TEST_DATA_DIR / "orcid_multiple_matches.json") as fh:
+        return cast(dict[str, Any], json.load(fh))
+
+
+@pytest.fixture
+def mocked_orcid(
+    monkeypatch: pytest.MonkeyPatch,
+    orcid_person_raw: dict[str, Any],
+    orcid_multiple_matches: dict[str, Any],
+) -> None:
+    response_query = Mock(spec=Response, status_code=200)
+    session = MagicMock(spec=requests.Session)
+    session.get = MagicMock(side_effect=[response_query])
+
+    def __init__(self: OrcidConnector) -> None:
+        self._connection = MagicMock(spec=Connection, extend=Mock())
+        self._connection.extend.standard.paged_search = MagicMock(side_effect=[])
+        self.session = session
+
+    monkeypatch.setattr(OrcidConnector, "__init__", __init__)
+
+    def fetch(_self: OrcidConnector, filters: dict[str, Any]) -> dict[str, Any]:
+        if filters.get("given-and-family-names") in {
+            "john doe",
+            "John Doe",
+            "John O'Doe",
+        }:
+            return {"num-found": 1, "result": [orcid_person_raw]}
+        if filters.get("given-and-family-names") == "Multiple Doe":
+            return orcid_multiple_matches
+        return {"result": None, "num-found": 0}
+
+    monkeypatch.setattr(OrcidConnector, "fetch", fetch)
+
+    def build_query(filters: dict[str, Any]) -> str:
+        if "given-and-family-names" in filters:
+            return f'given-and-family-names:"{filters["given-and-family-names"]}"'
+        if "given-names" in filters:
+            return f"given-names:{filters['given-names']} AND family-name:{filters.get('family-name', '*')}"
+        return ""
+
+    monkeypatch.setattr(OrcidConnector, "build_query", build_query)
+
+    def get_data_by_id(_self: OrcidConnector, orcid_id: str) -> dict[str, Any]:
+        if orcid_id == "0009-0004-3041-5706":
+            return orcid_person_raw
+        return None
+
+    monkeypatch.setattr(OrcidConnector, "get_data_by_id", get_data_by_id)

--- a/tests/auxiliary/test_data/orcid_multiple_matches.json
+++ b/tests/auxiliary/test_data/orcid_multiple_matches.json
@@ -1,0 +1,75 @@
+{
+    "num-found": 10,
+    "result": [
+        {
+            "orcid-identifier": {
+                "host": "orcid.org",
+                "path": "0009-0005-5828-7053",
+                "uri": "https://orcid.org/0009-0005-5828-7053"
+            }
+        },
+        {
+            "orcid-identifier": {
+                "host": "orcid.org",
+                "path": "0000-0003-3648-8952",
+                "uri": "https://orcid.org/0000-0003-3648-8952"
+            }
+        },
+        {
+            "orcid-identifier": {
+                "host": "orcid.org",
+                "path": "0000-0002-7523-2549",
+                "uri": "https://orcid.org/0000-0002-7523-2549"
+            }
+        },
+        {
+            "orcid-identifier": {
+                "host": "orcid.org",
+                "path": "0000-0002-9056-5667",
+                "uri": "https://orcid.org/0000-0002-9056-5667"
+            }
+        },
+        {
+            "orcid-identifier": {
+                "host": "orcid.org",
+                "path": "0000-0002-3372-2005",
+                "uri": "https://orcid.org/0000-0002-3372-2005"
+            }
+        },
+        {
+            "orcid-identifier": {
+                "host": "orcid.org",
+                "path": "0000-0001-7659-8932",
+                "uri": "https://orcid.org/0000-0001-7659-8932"
+            }
+        },
+        {
+            "orcid-identifier": {
+                "host": "orcid.org",
+                "path": "0009-0005-0959-5447",
+                "uri": "https://orcid.org/0009-0005-0959-5447"
+            }
+        },
+        {
+            "orcid-identifier": {
+                "host": "orcid.org",
+                "path": "0009-0000-4002-171X",
+                "uri": "https://orcid.org/0009-0000-4002-171X"
+            }
+        },
+        {
+            "orcid-identifier": {
+                "host": "orcid.org",
+                "path": "0009-0006-0442-1402",
+                "uri": "https://orcid.org/0009-0006-0442-1402"
+            }
+        },
+        {
+            "orcid-identifier": {
+                "host": "orcid.org",
+                "path": "0009-0006-9954-421X",
+                "uri": "https://orcid.org/0009-0006-9954-421X"
+            }
+        }
+    ]
+}

--- a/tests/auxiliary/test_data/orcid_person_raw.json
+++ b/tests/auxiliary/test_data/orcid_person_raw.json
@@ -1,0 +1,38 @@
+{
+    "orcid-identifier": {
+        "host": "orcid.org",
+        "path": "0009-0004-3041-5706",
+        "uri": "https://orcid.org/0009-0004-3041-5706"
+    },
+    "path": "/0009-0004-3041-5706",
+    "person": {
+        "emails": {
+            "email": [],
+            "path": "/0009-0004-3041-5706/email"
+        },
+        "name": {
+            "created-date": {
+                "value": 1729001670037
+            },
+            "family-name": {
+                "value": "Doe"
+            },
+            "given-names": {
+                "value": "John"
+            },
+            "last-modified-date": {
+                "value": 1730814244255
+            },
+            "path": "0009-0004-3041-5706",
+            "visibility": "public"
+        },
+        "other-names": {
+            "other-name": [],
+            "path": "/0009-0004-3041-5706/other-names"
+        },
+        "researcher-urls": {
+            "path": "/0009-0004-3041-5706/researcher-urls",
+            "researcher-url": []
+        }
+    }
+}

--- a/tests/auxiliary/test_orcid.py
+++ b/tests/auxiliary/test_orcid.py
@@ -1,0 +1,108 @@
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from mex.common.orcid.connector import OrcidConnector
+
+john_doe_response = {
+    "hadPrimarySource": "Naj2hOJq9FNRkkMWa5Qd0",
+    "identifierInPrimarySource": "0009-0004-3041-5706",
+    "affiliation": [],
+    "email": [],
+    "familyName": ["Doe"],
+    "fullName": [],
+    "givenName": ["John"],
+    "isniId": [],
+    "memberOf": [],
+    "orcidId": ["https://orcid.org/0009-0004-3041-5706"],
+    "$type": "ExtractedPerson",
+    "identifier": "eLFbvlVkwRgGxLnS8RywZ3",
+    "stableTargetId": "ccM55btPUrNtYKSLX8cNQP",
+}
+
+
+@pytest.mark.parametrize(
+    ("search_string", "status_code"),
+    [
+        ("John Doe", 200),
+        ("john doe", 200),
+        ("John O'Doe", 200),
+        ("", 422),
+    ],
+    ids=[
+        "existing Person by name",
+        "case insensitiv",
+        "special symbols",
+        "empty search String",
+    ],
+)
+@pytest.mark.usefixtures("mocked_orcid")
+def test_search_persons_in_orcid_mocked(
+    client_with_api_key_read_permission: TestClient,
+    search_string,
+    status_code,
+) -> None:
+    response = client_with_api_key_read_permission.get(
+        "/v0/orcid", params={"q": search_string}
+    )
+    assert response.status_code == status_code
+
+    if response.status_code == 200:
+        response_data = response.json()
+        assert response_data["total"] == len(response_data["items"])
+        assert response_data["items"] == [john_doe_response]
+    elif response.status_code == 422:
+        response_data = response.json()
+        assert response_data == {
+            "detail": [
+                {
+                    "type": "string_too_short",
+                    "loc": ["query", "q"],
+                    "msg": "String should have at least 1 character",
+                    "input": "",
+                    "ctx": {"min_length": 1},
+                }
+            ]
+        }
+
+
+@pytest.mark.parametrize(
+    ("search_string", "expected_status"),
+    [("None Doe", 404), ("Multiple Doe", 400)],
+    ids=["Non-existent", "Multiple Results"],
+)
+@pytest.mark.usefixtures("mocked_orcid")
+def test_search_persons_in_orcid_errors(
+    client_with_api_key_read_permission: TestClient, search_string, expected_status
+):
+    response = client_with_api_key_read_permission.get(
+        "/v0/orcid", params={"q": search_string}
+    )
+    assert response.status_code == expected_status
+    if response.status_code == 404:
+        assert response.text == '{"detail":"No results found for \'None Doe\'."}'
+    else:
+        assert (
+            response.text == '{"detail":"Multiple persons found for \'Multiple Doe\'."}'
+        )
+
+
+@pytest.mark.parametrize(
+    ("filters", "expected_output"),
+    [
+        (
+            {"given-and-family-names": "'John Doe'"},
+            "given-and-family-names:\"'John Doe'\"",
+        ),
+        (
+            {"given-names": "John", "family-name": "Doe"},
+            "given-names:John AND family-name:Doe",
+        ),
+    ],
+    ids=["Non-existent", "Multiple Results"],
+)
+@pytest.mark.usefixtures("mocked_orcid")
+def test_build_query(filters: dict[str, Any], expected_output: str):
+    built_query = OrcidConnector.build_query(filters)
+    assert built_query == expected_output


### PR DESCRIPTION
### PR Context
<!-- Additional info for the reviewer -->

### Added
- ORCID search endpoint in mex-backend
  - endpoint returning orcid persons (tranformed to ExtractedPersons)
  - full-text search query parameter `q` and pagination parameters `offset` and `limit`
  - response body contains
      - items: list[ExtractedPerson]  - the current "page" of search results
      - total: int  - the total number of persons found for this request

### Changes
<!-- Changes in existing functionality -->

### Deprecated
<!-- Soon-to-be removed features -->

### Removed
<!-- Definitely removed features -->

### Fixed
<!-- Fixed bugs -->

### Security
<!-- Fixed vulnerabilities -->
