### PR TITLE
Feature/mx 1823 improve ingest speed in backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - print runtimes in backend api connector for ingesting merged items and edges
-- test data set for benchmarking runtimes (not working yet
+- test data set for benchmarking runtimes (not working yet)
+- simplify merge_edges query template
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- print runtimes in backend api connector for ingesting merged items and edges
+- test data set for benchmarking runtimes (not working yet
+
 ### Changes
 
 ### Deprecated

--- a/mex/backend/graph/connector.py
+++ b/mex/backend/graph/connector.py
@@ -1,4 +1,5 @@
 import json
+import time
 from collections.abc import Sequence
 from string import Template
 from typing import Annotated, Any, Literal, cast
@@ -55,7 +56,7 @@ from mex.common.types import (
     MergedPrimarySourceIdentifier,
     Text,
 )
-import time
+
 
 class MExPrimarySource(BasePrimarySource):
     """An automatically extracted metadata set describing a primary source."""
@@ -584,7 +585,7 @@ class GraphConnector(BaseConnector):
                         model.stableTargetId,
                         identifier=model.identifier,
                     )
-            print(f"ingest items time: {time.time()-t0}")
+            print(f"ingest items time: {time.time() - t0}")
             t0 = time.time()
             for model in models:
                 if isinstance(model, AnyRuleSetResponse):
@@ -602,7 +603,7 @@ class GraphConnector(BaseConnector):
                         model.stableTargetId,
                         identifier=model.identifier,
                     )
-            print(f"ingest edges time: {time.time()-t0}")
+            print(f"ingest edges time: {time.time() - t0}")
 
         return list(models)
 

--- a/mex/backend/graph/connector.py
+++ b/mex/backend/graph/connector.py
@@ -461,9 +461,17 @@ class GraphConnector(BaseConnector):
             current_label=model.entityType,
             current_constraints=sorted(constraints),
             merged_label=ensure_prefix(model.stemType, "Merged"),
-            nested_edge_labels=nested_edge_labels,
-            nested_node_labels=nested_node_labels,
         )
+        nested_nodes = [
+            {"label": nl, "rel_type": r, "position": p, "value": v}
+            for nl, r, p, v in zip(
+                nested_node_labels,
+                nested_edge_labels,
+                nested_positions,
+                nested_values,
+                strict=True,
+            )
+        ]
 
         return self.commit(
             query,
@@ -471,9 +479,8 @@ class GraphConnector(BaseConnector):
             stable_target_id=stable_target_id,
             on_match=mutable_values,
             on_create=all_values,
-            nested_values=nested_values,
-            nested_positions=nested_positions,
             **constraints,
+            nested_nodes=nested_nodes,
         )
 
     def _merge_edges(

--- a/mex/backend/graph/connector.py
+++ b/mex/backend/graph/connector.py
@@ -523,15 +523,17 @@ class GraphConnector(BaseConnector):
             current_label=model.entityType,
             current_constraints=sorted(constraints),
             merged_label=ensure_prefix(model.stemType, "Merged"),
-            ref_labels=ref_labels,
         )
+        references = [
+            {"identifier": i, "position": p, "rel_type": r}
+            for i, p, r in zip(ref_identifiers, ref_positions, ref_labels, strict=True)
+        ]
         result = self.commit(
             query,
             session=session,
             stable_target_id=stable_target_id,
-            ref_identifiers=ref_identifiers,
-            ref_positions=ref_positions,
             **constraints,
+            references=references,
         )
 
         expectations_by_locator = transform_edges_into_expectations_by_edge_locator(

--- a/mex/backend/graph/connector.py
+++ b/mex/backend/graph/connector.py
@@ -55,7 +55,7 @@ from mex.common.types import (
     MergedPrimarySourceIdentifier,
     Text,
 )
-
+import time
 
 class MExPrimarySource(BasePrimarySource):
     """An automatically extracted metadata set describing a primary source."""
@@ -572,6 +572,7 @@ class GraphConnector(BaseConnector):
             List of identifiers of the ingested models
         """
         with self.driver.session() as session:
+            t0 = time.time()
             for model in models:
                 if isinstance(model, AnyRuleSetResponse):
                     for rule in (model.additive, model.subtractive, model.preventive):
@@ -583,7 +584,8 @@ class GraphConnector(BaseConnector):
                         model.stableTargetId,
                         identifier=model.identifier,
                     )
-
+            print(f"ingest items time: {time.time()-t0}")
+            t0 = time.time()
             for model in models:
                 if isinstance(model, AnyRuleSetResponse):
                     for rule in (model.additive, model.subtractive, model.preventive):
@@ -600,6 +602,7 @@ class GraphConnector(BaseConnector):
                         model.stableTargetId,
                         identifier=model.identifier,
                     )
+            print(f"ingest edges time: {time.time()-t0}")
 
         return list(models)
 

--- a/mex/backend/graph/cypher/merge_edges.cql
+++ b/mex/backend/graph/cypher/merge_edges.cql
@@ -21,17 +21,17 @@ Returns:
 -#>
 MATCH (source:<<current_label>> {<<current_constraints|render_constraints>>})-[:stableTargetId]->({identifier: $stable_target_id})
 CALL (source) {
-  WITH source
-  UNWIND $references AS ref
-  MATCH (target {identifier: ref.identifier})
-  CALL apoc.merge.relationship(source, ref.rel_type, {position: ref.position}, {}, target) YIELD rel AS edge
-  RETURN edge
+    WITH source
+    UNWIND $references AS ref
+    MATCH (target {identifier: ref.identifier})
+    CALL apoc.merge.relationship(source, ref.rel_type, {position: ref.position}, {}, target) YIELD rel AS edge
+    RETURN edge
 }
 WITH source, count(edge) AS merged, collect(edge) AS edges
 CALL (source, edges) {
-  MATCH (source)-[outdated_edge]->(:<<merged_labels|join("|")>>)
-  WHERE NOT outdated_edge IN edges
-  DELETE outdated_edge
-  RETURN count(outdated_edge) AS pruned
+    MATCH (source)-[outdated_edge]->(:<<merged_labels|join("|")>>)
+    WHERE NOT outdated_edge IN edges
+    DELETE outdated_edge
+    RETURN count(outdated_edge) AS pruned
 }
 RETURN merged, pruned, edges;

--- a/mex/backend/graph/cypher/merge_edges.cql
+++ b/mex/backend/graph/cypher/merge_edges.cql
@@ -21,24 +21,17 @@ Returns:
 -#>
 MATCH (source:<<current_label>> {<<current_constraints|render_constraints>>})-[:stableTargetId]->({identifier: $stable_target_id})
 CALL (source) {
-<%- if ref_labels %>
-<%- set union = joiner("UNION ALL\n    ") %>
-<%- for ref_label in ref_labels %>
-<%- set index = loop.index0 %>
-    <<union()>>WITH source
-    MATCH (target_<<index>> {identifier: $ref_identifiers[<<index>>]})
-    MERGE (source)-[edge:<<ref_label>> {position: $ref_positions[<<index>>]}]->(target_<<index>>)
-    RETURN edge
-<%- endfor %>
-<%- else %>
-    RETURN null AS edge
-<%- endif %>
+  WITH source
+  UNWIND $references AS ref
+  MATCH (target {identifier: ref.identifier})
+  CALL apoc.merge.relationship(source, ref.rel_type, {position: ref.position}, {}, target) YIELD rel AS edge
+  RETURN edge
 }
 WITH source, count(edge) AS merged, collect(edge) AS edges
 CALL (source, edges) {
-    MATCH (source)-[outdated_edge]->(:<<merged_labels|join("|")>>)
-    WHERE NOT outdated_edge IN edges
-    DELETE outdated_edge
-    RETURN count(outdated_edge) AS pruned
+  MATCH (source)-[outdated_edge]->(:<<merged_labels|join("|")>>)
+  WHERE NOT outdated_edge IN edges
+  DELETE outdated_edge
+  RETURN count(outdated_edge) AS pruned
 }
 RETURN merged, pruned, edges;

--- a/mex/backend/graph/cypher/merge_item.cql
+++ b/mex/backend/graph/cypher/merge_item.cql
@@ -31,15 +31,22 @@ MERGE (merged:<<merged_label>> {identifier: $stable_target_id})
 MERGE (current:<<current_label>> {<<current_constraints|render_constraints>>})-[:stableTargetId {position: 0}]->(merged)
 ON CREATE SET current = $on_create
 ON MATCH SET current += $on_match
-<%- for edge_label in nested_edge_labels -%>
-<%- set index = loop.index0 %>
-MERGE (current)-[edge_<<index>>:<<edge_label>> {position: $nested_positions[<<index>>]}]->(value_<<index>>:<<nested_node_labels[index]>>)
-ON CREATE SET value_<<index>> = $nested_values[<<index>>]
-ON MATCH SET value_<<index>> += $nested_values[<<index>>]
-<%- endfor %>
-WITH current,
-    [<<range(nested_edge_labels|count)|map("ensure_prefix", "edge_")|join(", ")>>] AS edges,
-    [<<range(nested_edge_labels|count)|map("ensure_prefix", "value_")|join(", ")>>] AS values
+
+WITH current, $nested_nodes AS nested_data
+UNWIND nested_data AS row
+
+CALL (row) {
+    WITH row
+    CALL apoc.cypher.run(
+      'MATCH (value:`' + row.label + '` {identifier: $id}) RETURN value',
+      {id: row.value.identifier}
+    ) YIELD value
+    RETURN value
+}
+
+CALL apoc.merge.relationship(current, row.rel_type, {position: row.position}, {}, value) YIELD rel AS edge
+
+WITH current, collect(edge) AS edges, collect(value) AS values
 CALL (current, values) {
     MATCH (current)-[]->(outdated_node:<<nested_labels|join("|")>>)
     WHERE NOT outdated_node IN values

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,39 @@
+import json
+
+from mex.backend.graph.connector import GraphConnector
+from mex.backend.merged.helpers import EXTRACTED_MODEL_ADAPTER
+from mex.backend.settings import BackendSettings
+
+Payload = dict[str, list[dict[str, Any]]]
+from mex.common.backend_api.connector import BackendApiConnector
+
+
+def test_bulk_insert() -> None:
+    files = [
+        r"C:\Users\esinsj\code\mex-extractors\ExtractedPrimarySource.ndjson",
+        r"C:\Users\esinsj\code\mex-extractors\ExtractedOrganization.ndjson",
+        r"C:\Users\esinsj\code\mex-extractors\ExtractedOrganizationalUnit.ndjson",
+        r"C:\Users\esinsj\code\mex-extractors\ExtractedResource.ndjson",
+        r"C:\Users\esinsj\code\mex-extractors\ExtractedVariableGroup.ndjson",
+    ]
+    settings = BackendSettings.get()
+
+    connector = BackendApiConnector.get()
+    graph_connector = GraphConnector.get()
+    graph_connector.flush()
+    graph_connector.close()
+    for f in files:
+        with open(f) as fh:
+            post_payload = []
+            for l in fh:
+                post_payload.append(
+                    EXTRACTED_MODEL_ADAPTER.validate_python(json.loads(l))
+                )
+
+            # post the dummy data to the ingest endpoint
+            connector.ingest(post_payload)
+    connector.close()
+
+
+if __name__ == "__main__":
+    test_bulk_insert()


### PR DESCRIPTION
### Added
- print runtimes in backend api connector for ingesting merged items and edges
- test data set for benchmarking runtimes (not working yet)
- simplify merge_edges query template with Apoc and Unwind

Note: 
Get Apoc :

* Install APOC: In Neo4J
** Set Proxy (if not set)
** click on local DB > Plugins (in right window)> APOC > install 
		    (https://neo4j.com/docs/apoc/current/installation/)
** Restart Neo4j
* Edit conf: in neo4J
** click on "…" next to local DB > Settings
** Search for (strg + f), uncomment and replace the security settings with:
**** dbms.security.procedures.unrestricted=apoc.merge.relationship
**** dbms.security.procedures.allowlist=apoc.merge.relationship
