### PR TITLE
feature/mx-1823-label-narrowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- add settings for `graph_tx_timeout` and `graph_session_timeout`
+
 ### Changes
+
+- explicitly configure read/write access level per query type
+- narrow-down labels of link and create nodes to speed up ingest query
+- improve `validate_ingested_data` with clearer error details
 
 ### Deprecated
 

--- a/mex/backend/fields.py
+++ b/mex/backend/fields.py
@@ -1,5 +1,6 @@
 from itertools import chain
 
+from mex.backend.utils import contains_any_types
 from mex.common.fields import (
     ALL_MODEL_CLASSES_BY_NAME,
     EMAIL_FIELDS_BY_CLASS_NAME,
@@ -7,7 +8,7 @@ from mex.common.fields import (
     STRING_FIELDS_BY_CLASS_NAME,
 )
 from mex.common.types import MERGED_IDENTIFIER_CLASSES
-from mex.common.utils import contains_only_types, get_all_fields
+from mex.common.utils import get_all_fields
 
 # fields that should be indexed as searchable fields
 SEARCHABLE_FIELDS = sorted(
@@ -37,9 +38,10 @@ SEARCHABLE_CLASSES = sorted(
 REFERENCED_ENTITY_TYPES_BY_FIELD_BY_CLASS_NAME = {
     class_name: {
         field_name: sorted(
+            # TODO(ND): move this into mex-common instead of relying on convention
             identifier_class.__name__.removesuffix("Identifier")
             for identifier_class in MERGED_IDENTIFIER_CLASSES
-            if contains_only_types(
+            if contains_any_types(
                 get_all_fields(ALL_MODEL_CLASSES_BY_NAME[class_name])[field_name],
                 identifier_class,
             )
@@ -52,5 +54,7 @@ REFERENCED_ENTITY_TYPES_BY_FIELD_BY_CLASS_NAME = {
 # all referenced entity types grouped by class name
 REFERENCED_ENTITY_TYPES_BY_CLASS_NAME = {
     class_name: sorted(chain(*types_by_field.values()))
-    for class_name, types_by_field in REFERENCED_ENTITY_TYPES_BY_FIELD_BY_CLASS_NAME.items()
+    for class_name, types_by_field in (
+        REFERENCED_ENTITY_TYPES_BY_FIELD_BY_CLASS_NAME.items()
+    )
 }

--- a/mex/backend/graph/connector.py
+++ b/mex/backend/graph/connector.py
@@ -118,40 +118,49 @@ class GraphConnector(BaseConnector):
     def _seed_constraints(self) -> list[Result]:
         """Ensure uniqueness constraints are enabled for all entity types."""
         query_builder = QueryBuilder.get()
-        results = [
-            self.commit(
-                query_builder.create_identifier_uniqueness_constraint(
-                    node_label=class_name
+        with self.driver.session(default_access_mode=WRITE_ACCESS) as session:
+            results = [
+                self.commit(
+                    query_builder.create_identifier_uniqueness_constraint(
+                        node_label=class_name
+                    ),
+                    session=session,
                 )
-            )
-            for class_name in sorted(
-                set(EXTRACTED_MODEL_CLASSES_BY_NAME) | set(MERGED_MODEL_CLASSES_BY_NAME)
-            )
-        ]
+                for class_name in sorted(
+                    set(EXTRACTED_MODEL_CLASSES_BY_NAME)
+                    | set(MERGED_MODEL_CLASSES_BY_NAME)
+                )
+            ]
         logger.info("seeded identifier uniqueness constraints")
         return results
 
     def _seed_indices(self) -> Result:
         """Ensure there is a full text search index for all searchable fields."""
         query_builder = QueryBuilder.get()
-        result = self.commit(query_builder.fetch_full_text_search_index())
-        if (index := result.one_or_none()) and (
-            set(index["node_labels"]) != set(SEARCHABLE_CLASSES)
-            or set(index["search_fields"]) != set(SEARCHABLE_FIELDS)
-        ):
-            # only drop the index if the classes or fields have changed
-            self.commit(query_builder.drop_full_text_search_index())
-            logger.info("searchable fields changed: dropped indices")
-        result = self.commit(
-            query_builder.create_full_text_search_index(
-                node_labels=SEARCHABLE_CLASSES,
-                search_fields=SEARCHABLE_FIELDS,
-            ),
-            index_config={
-                "fulltext.eventually_consistent": True,
-                "fulltext.analyzer": "german",
-            },
-        )
+        with self.driver.session(default_access_mode=WRITE_ACCESS) as session:
+            result = self.commit(
+                query_builder.fetch_full_text_search_index(), session=session
+            )
+            if (index := result.one_or_none()) and (
+                set(index["node_labels"]) != set(SEARCHABLE_CLASSES)
+                or set(index["search_fields"]) != set(SEARCHABLE_FIELDS)
+            ):
+                # only drop the index if the classes or fields have changed
+                self.commit(
+                    query_builder.drop_full_text_search_index(), session=session
+                )
+                logger.info("searchable fields changed: dropped indices")
+            result = self.commit(
+                query_builder.create_full_text_search_index(
+                    node_labels=SEARCHABLE_CLASSES,
+                    search_fields=SEARCHABLE_FIELDS,
+                ),
+                session=session,
+                index_config={
+                    "fulltext.eventually_consistent": True,
+                    "fulltext.analyzer": "german",
+                },
+            )
         logger.info("created full text search index")
         return result
 
@@ -627,11 +636,14 @@ class GraphConnector(BaseConnector):
         """Flush the database (only in debug mode)."""
         settings = BackendSettings.get()
         if settings.debug is True:
-            self.driver.execute_query("MATCH (n) DETACH DELETE n;")
-            for row in self.driver.execute_query("SHOW ALL CONSTRAINTS;").records:
-                self.driver.execute_query(f"DROP CONSTRAINT {row['name']};")
-            for row in self.driver.execute_query("SHOW ALL INDEXES;").records:
-                self.driver.execute_query(f"DROP INDEX {row['name']};")
+            with self.driver.session(default_access_mode=WRITE_ACCESS) as session:
+                session.run("MATCH (n) DETACH DELETE n;")
+                constraints = session.run("SHOW ALL CONSTRAINTS;")
+                for row in constraints.to_eager_result().records:
+                    session.run(f"DROP CONSTRAINT {row['name']};")
+                indexes = session.run("SHOW ALL INDEXES;")
+                for row in indexes.to_eager_result().records:
+                    session.run(f"DROP INDEX {row['name']};")
         else:
             msg = "database flush was attempted outside of debug mode"
             raise MExError(msg)

--- a/mex/backend/graph/cypher/merge_item_v2.cql
+++ b/mex/backend/graph/cypher/merge_item_v2.cql
@@ -49,7 +49,7 @@ CALL (main, data) {
     ORDER BY type(linkEdge), linkEdge.position
     RETURN collect(
         {
-            nodeLabels: [],
+            nodeLabels: labels(linkNode),
             nodeProps: properties(linkNode),
             edgeLabel: type(linkEdge),
             edgeProps: properties(linkEdge)

--- a/mex/backend/graph/cypher/merge_item_v2.cql
+++ b/mex/backend/graph/cypher/merge_item_v2.cql
@@ -1,15 +1,16 @@
 WITH $data AS data
 
 <# create merged node if not exist -#>
-MERGE (merged:$(data.mergedLabels) {identifier: data.stableTargetId})
+MERGE (merged:<<params.merged_label>> {identifier: data.stableTargetId})
 <# create extracted/rule node if not exists -#>
-MERGE (main:$(data.nodeLabels) {identifier: data.identifier})
+MERGE (main:<<params.node_label>> {identifier: data.identifier})
 <# connect extracted/rule node with merged node -#>
 MERGE (main)-[:stableTargetId {position: 0}]->(merged)
 SET main += data.nodeProps
 
-WITH main, merged, data
+WITH main, merged.identifier AS stableTargetId, data
 
+<% if params.has_create_rels -%>
 <# create Text/Link nodes and connect them to extracted/rule item -#>
 CALL (main, data) {
     UNWIND data.createRels AS createRel
@@ -17,34 +18,56 @@ CALL (main, data) {
     SET creationTarget += createRel.nodeProps
     RETURN collect(newCreateEdge) as newCreateEdges
 }
+<%- endif %>
 
+<% if params.has_link_rels -%>
 <# connect extracted/rule item to referenced merged items -#>
 CALL (main, data) {
     UNWIND data.linkRels AS linkRel
-    MATCH (linkTarget:$(linkRel.nodeLabels) {identifier: linkRel.nodeProps.identifier})
+    MATCH (linkTarget:<<params.all_referenced_labels|join("|")>> {identifier: linkRel.nodeProps.identifier})
     MERGE (main)-[newLinkEdge:$(linkRel.edgeLabel) {position: linkRel.edgeProps.position}]->(linkTarget)
     RETURN collect(newLinkEdge) as newLinkEdges
 }
+<%- endif %>
 
-<# delete referenced Text/Link nodes and their edges that are not in $data -#>
-CALL (main, newCreateEdges, data) {
-    OPTIONAL MATCH (main)-[gcEdge]->(gcNode:$(data.allNestedLabels))
-        WHERE TYPE(gcEdge) IN data.deleteNodeEdges
-        AND NOT gcEdge IN newCreateEdges
+<% if params.has_create_rels -%>
+<# delete referenced Text/Link nodes and their edges that are not in newCreateEdges -#>
+CALL (main, newCreateEdges) {
+    OPTIONAL MATCH (main)-[gcEdge:<<params.delete_node_edges|join("|")>>]->(gcNode:<<params.all_nested_labels|join("|")>>)
+        WHERE NOT gcEdge IN newCreateEdges
     DETACH DELETE gcNode
 }
+<%- endif %>
 
-<# delete edges to merged nodes that are not in $data -#>
-CALL (main, newLinkEdges, data) {
-    OPTIONAL MATCH (main)-[gcEdge]->(:$(data.allReferencedLabels))
-    WHERE TYPE(gcEdge) IN data.detachNodeEdges
-    AND NOT gcEdge IN newLinkEdges
+<% if params.has_link_rels -%>
+<# delete edges to merged nodes that are not in newLinkEdges -#>
+CALL (main, newLinkEdges) {
+    OPTIONAL MATCH (main)-[gcEdge:<<params.detach_node_edges|join("|")>>]->(:<<params.all_referenced_labels|join("|")>>)
+    WHERE NOT gcEdge IN newLinkEdges
     DELETE gcEdge
 }
+<%- endif %>
+
+<% if params.has_create_rels -%>
+<# get all relations to nested items -#>
+CALL (main) {
+    MATCH (main)-[createEdge]->(createNode:<<params.all_nested_labels|join("|")>>)
+    ORDER BY type(createEdge), createEdge.position
+    RETURN collect(
+        {
+            nodeLabels: labels(createNode),
+            nodeProps: properties(createNode),
+            edgeLabel: type(createEdge),
+            edgeProps: properties(createEdge)
+        }
+    ) AS createRels
+}
+<%- endif %>
 
 <# get all relations to merged items that are not of relation type "stableTargetId" -#>
-CALL (main, data) {
-    MATCH (main)-[linkEdge]->(linkNode:$(data.allReferencedLabels))
+<% if params.has_link_rels -%>
+CALL (main) {
+    MATCH (main)-[linkEdge]->(linkNode:<<params.all_referenced_labels|join("|")>>)
     WHERE type(linkEdge) <> "stableTargetId"
     ORDER BY type(linkEdge), linkEdge.position
     RETURN collect(
@@ -56,27 +79,17 @@ CALL (main, data) {
         }
     ) AS linkRels
 }
-
-<# get all relations to nested items -#>
-CALL (main, data) {
-    MATCH (main)-[createEdge]->(createNode:$(data.allNestedLabels))
-    ORDER BY type(createEdge), createEdge.position
-    RETURN collect(
-        {
-            nodeLabels: labels(createNode),
-            nodeProps: properties(createNode),
-            edgeLabel: type(createEdge),
-            edgeProps: properties(createEdge)
-        }
-    ) AS createRels
-}
+<%- endif %>
 
 <# return current state for validation -#>
 RETURN
     main.identifier AS identifier,
-    merged.identifier AS stableTargetId,
-    labels(merged) AS mergedLabels,
-    labels(main) AS nodeLabels,
-    properties(main) AS nodeProps,
-    linkRels AS linkRels,
-    createRels AS createRels;
+    stableTargetId,
+    head(labels(main)) AS entityType,
+<%- if params.has_link_rels %>
+    linkRels,
+<%- endif %>
+<%- if params.has_create_rels %>
+    createRels,
+<%- endif %>
+    properties(main) AS nodeProps;

--- a/mex/backend/graph/cypher/merge_item_v2.cql
+++ b/mex/backend/graph/cypher/merge_item_v2.cql
@@ -12,39 +12,39 @@ WITH main, merged, data
 
 <# create Text/Link nodes and connect them to extracted/rule item -#>
 CALL (main, data) {
-    UNWIND data.createRels AS rel
-    MERGE (main)-[newEdge:$(rel.edgeLabel) {position: rel.edgeProps.position}]->(target:$(rel.nodeLabels))
-    SET target += rel.nodeProps
-    RETURN collect(newEdge) as newCreateEdges
+    UNWIND data.createRels AS createRel
+    MERGE (main)-[newCreateEdge:$(createRel.edgeLabel) {position: createRel.edgeProps.position}]->(creationTarget:$(createRel.nodeLabels))
+    SET creationTarget += createRel.nodeProps
+    RETURN collect(newCreateEdge) as newCreateEdges
 }
 
 <# connect extracted/rule item to referenced merged items -#>
 CALL (main, data) {
-    UNWIND data.linkRels AS rel
-    MATCH (target:$(rel.nodeLabels) {identifier: rel.nodeProps.identifier})
-    MERGE (main)-[newEdge:$(rel.edgeLabel) {position: rel.edgeProps.position}]->(target)
-    RETURN collect(newEdge) as newLinkEdges
+    UNWIND data.linkRels AS linkRel
+    MATCH (linkTarget:$(linkRel.nodeLabels) {identifier: linkRel.nodeProps.identifier})
+    MERGE (main)-[newLinkEdge:$(linkRel.edgeLabel) {position: linkRel.edgeProps.position}]->(linkTarget)
+    RETURN collect(newLinkEdge) as newLinkEdges
 }
 
 <# delete referenced Text/Link nodes and their edges that are not in $data -#>
 CALL (main, newCreateEdges, data) {
-    OPTIONAL MATCH (main)-[gcEdge]->(gcNode)
-        WHERE TYPE(gcEdge) IN data.deleteNodes
+    OPTIONAL MATCH (main)-[gcEdge]->(gcNode:$(data.allNestedLabels))
+        WHERE TYPE(gcEdge) IN data.deleteNodeEdges
         AND NOT gcEdge IN newCreateEdges
     DETACH DELETE gcNode
 }
 
 <# delete edges to merged nodes that are not in $data -#>
 CALL (main, newLinkEdges, data) {
-    OPTIONAL MATCH (main)-[gcEdge]->()
-    WHERE TYPE(gcEdge) IN data.detachNodes
+    OPTIONAL MATCH (main)-[gcEdge]->(:$(data.allReferencedLabels))
+    WHERE TYPE(gcEdge) IN data.detachNodeEdges
     AND NOT gcEdge IN newLinkEdges
     DELETE gcEdge
 }
 
 <# get all relations to merged items that are not of relation type "stableTargetId" -#>
-CALL (main) {
-    MATCH (main)-[linkEdge]->(linkNode:<<merged_labels|join("|")>>)
+CALL (main, data) {
+    MATCH (main)-[linkEdge]->(linkNode:$(data.allReferencedLabels))
     WHERE type(linkEdge) <> "stableTargetId"
     ORDER BY type(linkEdge), linkEdge.position
     RETURN collect(
@@ -58,8 +58,8 @@ CALL (main) {
 }
 
 <# get all relations to nested items -#>
-CALL (main) {
-    MATCH (main)-[createEdge]->(createNode:<<nested_labels|join("|")>>)
+CALL (main, data) {
+    MATCH (main)-[createEdge]->(createNode:$(data.allNestedLabels))
     ORDER BY type(createEdge), createEdge.position
     RETURN collect(
         {
@@ -79,6 +79,4 @@ RETURN
     labels(main) AS nodeLabels,
     properties(main) AS nodeProps,
     linkRels AS linkRels,
-    createRels AS createRels,
-    data.deleteNodes as deleteNodes,
-    data.detachNodes as detachNodes;
+    createRels AS createRels;

--- a/mex/backend/graph/models.py
+++ b/mex/backend/graph/models.py
@@ -127,8 +127,10 @@ class IngestData(BaseModel):
     nodeProps: dict[str, GraphValueType]
     linkRels: list[GraphRel]
     createRels: list[GraphRel]
-    detachNodes: list[str] = []
-    deleteNodes: list[str] = []
+    detachNodeEdges: list[str] = []
+    allReferencedLabels: list[str] = []
+    deleteNodeEdges: list[str] = []
+    allNestedLabels: list[str] = []
 
     @field_validator("createRels", mode="before")
     @classmethod

--- a/mex/backend/graph/models.py
+++ b/mex/backend/graph/models.py
@@ -122,15 +122,10 @@ class IngestData(BaseModel):
 
     stableTargetId: str
     identifier: str
-    mergedLabels: list[str]
-    nodeLabels: list[str]
+    entityType: str
     nodeProps: dict[str, GraphValueType]
-    linkRels: list[GraphRel]
-    createRels: list[GraphRel]
-    detachNodeEdges: list[str] = []
-    allReferencedLabels: list[str] = []
-    deleteNodeEdges: list[str] = []
-    allNestedLabels: list[str] = []
+    linkRels: list[GraphRel] = []
+    createRels: list[GraphRel] = []
 
     @field_validator("createRels", mode="before")
     @classmethod
@@ -150,6 +145,18 @@ class IngestData(BaseModel):
             "createRels": len(self.createRels),
             "identifier": self.identifier,
             "linkRels": len(self.linkRels),
-            "nodeLabels": "|".join(self.nodeLabels),
             "props": len(self.nodeProps),
         }
+
+
+class IngestParams(BaseModel):
+    """Type definition for query parameters."""
+
+    merged_label: str
+    node_label: str
+    all_referenced_labels: list[str]
+    all_nested_labels: list[str]
+    detach_node_edges: list[str]
+    delete_node_edges: list[str]
+    has_link_rels: bool
+    has_create_rels: bool

--- a/mex/backend/graph/transform.py
+++ b/mex/backend/graph/transform.py
@@ -1,3 +1,4 @@
+from functools import cache
 from itertools import groupby
 from typing import Any, TypedDict, cast
 
@@ -5,10 +6,12 @@ from neo4j.exceptions import Neo4jError
 from pydantic_core import ErrorDetails
 
 from mex.backend.fields import (
+    NESTED_ENTITY_TYPES_BY_CLASS_NAME,
     REFERENCED_ENTITY_TYPES_BY_CLASS_NAME,
     REFERENCED_ENTITY_TYPES_BY_FIELD_BY_CLASS_NAME,
 )
-from mex.backend.graph.models import GraphRel, IngestData
+from mex.backend.graph.models import GraphRel, IngestData, IngestParams
+from mex.backend.graph.query import QueryBuilder
 from mex.common.fields import (
     FINAL_FIELDS_BY_CLASS_NAME,
     LINK_FIELDS_BY_CLASS_NAME,
@@ -16,9 +19,9 @@ from mex.common.fields import (
     REFERENCE_FIELDS_BY_CLASS_NAME,
     TEXT_FIELDS_BY_CLASS_NAME,
 )
-from mex.common.models import AnyExtractedModel
+from mex.common.models import EXTRACTED_MODEL_CLASSES_BY_NAME, AnyExtractedModel
 from mex.common.transform import ensure_prefix, to_key_and_values
-from mex.common.types import NESTED_MODEL_CLASSES_BY_NAME, AnyPrimitiveType, Link, Text
+from mex.common.types import AnyPrimitiveType, Link, Text
 
 
 class _SearchResultReference(TypedDict):
@@ -65,10 +68,34 @@ def transform_edges_into_expectations_by_edge_locator(
     }
 
 
+@cache
+def get_ingest_query_for_entity_type(entity_type: str) -> str:
+    """Create a v2 ingest query for the given entity type."""
+    stem_type = EXTRACTED_MODEL_CLASSES_BY_NAME[entity_type].stemType
+    merged_label = ensure_prefix(stem_type, "Merged")
+    text_fields = TEXT_FIELDS_BY_CLASS_NAME[entity_type]
+    link_fields = LINK_FIELDS_BY_CLASS_NAME[entity_type]
+    nested_types_for_class = NESTED_ENTITY_TYPES_BY_CLASS_NAME[entity_type]
+    ref_fields_for_class = REFERENCE_FIELDS_BY_CLASS_NAME[entity_type]
+    ref_fields = sorted(set(ref_fields_for_class) - {"stableTargetId"})
+    ref_types_for_class = REFERENCED_ENTITY_TYPES_BY_CLASS_NAME[entity_type]
+    params = IngestParams(
+        merged_label=merged_label,
+        node_label=entity_type,
+        all_referenced_labels=ref_types_for_class,
+        all_nested_labels=nested_types_for_class,
+        detach_node_edges=ref_fields,
+        delete_node_edges=[*text_fields, *link_fields],
+        has_link_rels=bool(ref_types_for_class),
+        has_create_rels=bool(nested_types_for_class),
+    )
+    query_builder = QueryBuilder.get()
+    query = query_builder.merge_item_v2(params=params)
+    return str(query)
+
+
 def transform_model_into_ingest_data(model: AnyExtractedModel) -> IngestData:
     """Transform the given model into an ingestion instruction."""
-    merged_label = ensure_prefix(model.stemType, "Merged")
-
     text_fields = TEXT_FIELDS_BY_CLASS_NAME[model.entityType]
     link_fields = LINK_FIELDS_BY_CLASS_NAME[model.entityType]
     mutable_fields = MUTABLE_FIELDS_BY_CLASS_NAME[model.entityType]
@@ -76,8 +103,6 @@ def transform_model_into_ingest_data(model: AnyExtractedModel) -> IngestData:
     ref_fields_for_class = REFERENCE_FIELDS_BY_CLASS_NAME[model.entityType]
     ref_fields = sorted(set(ref_fields_for_class) - {"stableTargetId"})
     ref_field_types = REFERENCED_ENTITY_TYPES_BY_FIELD_BY_CLASS_NAME[model.entityType]
-    ref_types_for_class = REFERENCED_ENTITY_TYPES_BY_CLASS_NAME[model.entityType]
-    all_ref_types = sorted(set(ref_types_for_class) | {merged_label})
 
     mutable_values = model.model_dump(include=set(mutable_fields))
     final_values = model.model_dump(include=set(final_fields))
@@ -119,15 +144,10 @@ def transform_model_into_ingest_data(model: AnyExtractedModel) -> IngestData:
     return IngestData(
         identifier=str(model.identifier),
         stableTargetId=str(model.stableTargetId),
-        mergedLabels=[merged_label],
-        nodeLabels=[model.entityType],
+        entityType=model.entityType,
         nodeProps=all_values,
         linkRels=link_rels,
         createRels=create_rels,
-        detachNodeEdges=ref_fields,
-        allReferencedLabels=all_ref_types,
-        deleteNodeEdges=[*text_fields, *link_fields],
-        allNestedLabels=sorted(NESTED_MODEL_CLASSES_BY_NAME),
     )
 
 
@@ -155,13 +175,7 @@ def validate_ingested_data(
 ) -> list[ErrorDetails]:
     """Validate that the ingestion has been executed successfully."""
     error_details = []
-    for field in (
-        "stableTargetId",
-        "identifier",
-        "mergedLabels",
-        "nodeLabels",
-        "nodeProps",
-    ):
+    for field in ("stableTargetId", "identifier", "entityType", "nodeProps"):
         value_in = clean_dict(getattr(data_in, field))
         value_out = clean_dict(getattr(data_out, field))
         if value_out != value_in:
@@ -174,10 +188,7 @@ def validate_ingested_data(
                     ctx={"expected": value_in},
                 )
             )
-    for rel_field in (
-        "linkRels",
-        "createRels",
-    ):
+    for rel_field in ("linkRels", "createRels"):
         in_lookup = {
             get_graph_rel_id(rel): cast("GraphRel", rel)
             for rel in getattr(data_in, rel_field)
@@ -198,21 +209,22 @@ def validate_ingested_data(
                         ctx={"expected": None},
                     )
                 )
-            elif not set(out_rel["nodeLabels"]) <= set(in_rel["nodeLabels"]):
+                continue
+            if not set(out_rel["nodeLabels"]) <= set(in_rel["nodeLabels"]):
                 error_details.append(
                     ErrorDetails(
                         type="transaction_failed",
-                        msg="referenced node contains unexpected labels",
+                        msg="referenced node has unexpected labels",
                         loc=(rel_field, *rel_id, "nodeLabels"),
                         input=out_rel["nodeLabels"],
                         ctx={"expected": in_rel["nodeLabels"]},
                     )
                 )
-            elif out_rel["nodeProps"] != in_rel["nodeProps"]:
+            if clean_dict(out_rel["nodeProps"]) != clean_dict(in_rel["nodeProps"]):
                 error_details.append(
                     ErrorDetails(
                         type="transaction_failed",
-                        msg="referenced node contains unexpected properties",
+                        msg="referenced node has unexpected properties",
                         loc=(rel_field, *rel_id, "nodeProps"),
                         input=out_rel["nodeProps"],
                         ctx={"expected": in_rel["nodeProps"]},

--- a/mex/backend/settings.py
+++ b/mex/backend/settings.py
@@ -46,6 +46,22 @@ class BackendSettings(BaseSettings):
         description="Password for authenticating with the graph database.",
         validation_alias="MEX_GRAPH_PASSWORD",
     )
+    graph_tx_timeout: int | float = Field(
+        15.0,
+        description=(
+            "The graph transaction timeout in seconds. "
+            "A 0 duration will make the transaction execute indefinitely. "
+            "None will use the default timeout configured on the server."
+        ),
+        validation_alias="MEX_GRAPH_TX_TIMEOUT",
+    )
+    graph_session_timeout: int | float = Field(
+        45.0,
+        description=(
+            "Maximum time transactions are allowed to retry via tx functions."
+        ),
+        validation_alias="MEX_GRAPH_SESSION_TIMEOUT",
+    )
     backend_api_key_database: APIKeyDatabase = Field(
         APIKeyDatabase(),
         description="Database of API keys.",

--- a/mex/backend/utils.py
+++ b/mex/backend/utils.py
@@ -1,0 +1,20 @@
+from mex.common.utils import GenericFieldInfo, get_inner_types
+
+
+def contains_any_types(field: GenericFieldInfo, *types: type) -> bool:
+    """Return whether a `field` is annotated as any of the given `types`.
+
+    Unions, lists and type annotations are checked for their inner types and only the
+    non-`NoneType` types are considered for the type-check.
+
+    Args:
+        field: A `GenericFieldInfo` instance
+        types: Types to look for in the field's annotation
+
+    Returns:
+        Whether the field contains any of the given types
+    """
+    # TODO(ND): move this into mex-common for completeness sake
+    if inner_types := list(get_inner_types(field.annotation, include_none=False)):
+        return any(inner_type in types for inner_type in inner_types)
+    return False

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:bd800e5b11c3221211650693de68973262a7b1abbb5b873debf45813db7c0592"
+content_hash = "sha256:b707c5dc674f162fc08263369cc73610282b4e42c16404b45aa7a8830dd15905"
 
 [[metadata.targets]]
 requires_python = "==3.11.*"
@@ -606,28 +606,28 @@ files = [
 
 [[package]]
 name = "mex-artificial"
-version = "0.4.1"
+version = "0.4.2"
 requires_python = ">=3.11,<3.13"
 git = "https://github.com/robert-koch-institut/mex-artificial.git"
-ref = "0.4.1"
-revision = "2c96f37c5f6dd8caadb9c2b7107a199e0ebe58c7"
+ref = "0.4.2"
+revision = "846e5d35bf2283463a938e00b5282adbbd99152c"
 summary = "Create artificial data for the MEx project."
 groups = ["dev"]
 dependencies = [
-    "annotated-types<1,<=0.7",
+    "annotated-types<=0.7",
     "faker<38,>=37",
-    "mex-common @ git+https://github.com/robert-koch-institut/mex-common.git@0.59.2",
-    "pydantic<3,>=2",
-    "typer<1,>=0.13",
+    "mex-common @ git+https://github.com/robert-koch-institut/mex-common.git@0.61.1",
+    "pydantic>=2",
+    "typer>=0.13",
 ]
 
 [[package]]
 name = "mex-common"
-version = "0.60.0"
+version = "0.61.1"
 requires_python = ">=3.11,<3.12"
 git = "https://github.com/robert-koch-institut/mex-common.git"
-ref = "0.60.0"
-revision = "f727d157c2ea89dd0e5d0925531c235a789c0133"
+ref = "0.61.1"
+revision = "564e9d41c4be9fc9c7b9d36c9c49b1dbe61c319e"
 summary = "Common library for MEx python projects."
 groups = ["default", "dev"]
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,21 +8,21 @@ license = { file = "LICENSE" }
 urls = { Repository = "https://github.com/robert-koch-institut/mex-backend" }
 requires-python = ">=3.11,<3.12"
 dependencies = [
-    "backoff>=2,<3",
-    "black>=25,<26",
-    "fastapi>=0.115,<1",
-    "jinja2>=3,<4",
-    "mex-common @ git+https://github.com/robert-koch-institut/mex-common.git@0.60.0",
-    "neo4j>=5,<6",
-    "pydantic>=2,<3",
-    "redis[hiredis]>=6,<7",
-    "starlette>=0.41,<1",
-    "uvicorn[standard]>=0.30,<1",
+    "backoff>=2",
+    "black>=25",
+    "fastapi>=0.115",
+    "jinja2>=3",
+    "mex-common @ git+https://github.com/robert-koch-institut/mex-common.git@0.61.1",
+    "neo4j>=5",
+    "pydantic>=2",
+    "redis[hiredis]>=6",
+    "starlette>=0.41",
+    "uvicorn[standard]>=0.30",
 ]
 optional-dependencies.dev = [
     "httpx>=0.27",
     "ipdb>=0.13",
-    "mex-artificial @ git+https://github.com/robert-koch-institut/mex-artificial.git@0.4.1",
+    "mex-artificial @ git+https://github.com/robert-koch-institut/mex-artificial.git@0.4.2",
     "mypy>=1",
     "pytest-cov>=6",
     "pytest-random-order>=1",

--- a/tests/auxiliary/test_orcid.py
+++ b/tests/auxiliary/test_orcid.py
@@ -11,7 +11,7 @@ john_doe_response = {
     "affiliation": [],
     "email": [],
     "familyName": ["Doe"],
-    "fullName": [],
+    "fullName": ["Doe, John"],
     "givenName": ["John"],
     "isniId": [],
     "memberOf": [],


### PR DESCRIPTION
### Added

- add settings for `graph_tx_timeout` and `graph_session_timeout`

### Changes

- explicitly configure read/write access level per query type
- narrow-down labels of link and create nodes to speed up ingest query
- improve `validate_ingested_data` with clearer error details
