### PR TITLE
Bump cookiecutter template to 1.3.0

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,14 +1,14 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "0d8c4782a38f66faeaa24cc853c191cc624a9dff",
-  "checkout": null,
+  "commit": "192830effd8041fcff795b110a3915093c96c00e",
+  "checkout": "1.3.0",
   "context": {
     "cookiecutter": {
       "project_name": "backend",
       "short_summary": "Backend server for the RKI metadata exchange.",
       "long_summary": "The `mex-backend` package is a multi-purpose backend application with an HTTP-API. It provides endpoints to ingest data from ETL-pipelines, for a metadata editor application, and for publishing pipelines to extract standardized data for use in upstream frontend applications.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "0d8c4782a38f66faeaa24cc853c191cc624a9dff"
+      "_commit": "192830effd8041fcff795b110a3915093c96c00e"
     }
   },
   "directory": null

--- a/.github/workflows/cookiecutter.yml
+++ b/.github/workflows/cookiecutter.yml
@@ -64,6 +64,8 @@ jobs:
 
       - name: Update template and commit
         id: update
+        env:
+          GH_TOKEN: ${{ secrets.MEX_COOKIECUTTER_TOKEN }}
         run: |
           template_url=$(python -c "print(__import__('json').load(open('.cruft.json'))['template'])")
           template_tag=$(git ls-remote --tags --sort=-v:refname "${template_url}" | grep -v '\^{}' | head -1 | sed 's|.*refs/tags/||')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,7 @@ jobs:
           IMAGE: ghcr.io/${{ github.repository }}
           TAG: ${{ needs.release.outputs.tag }}
         with:
+          context: .
           push: true
           tags: |
             ${{ env.IMAGE }}:latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- new template https://github.com/robert-koch-institut/mex-template/releases/tag/1.3.0
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/0d8c47
 
 - updated mex-common to 3.0.0


### PR DESCRIPTION
### Changes

- new template https://github.com/robert-koch-institut/mex-template/releases/tag/1.3.0
