### PR TITLE
hotfix/http-test-server-docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- added missing http-test-server executable to final stage of docker image
+
 ### Security
 
 ## [4.0.1] - 2026-07-01

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ WORKDIR /app
 COPY --from=builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
 COPY --from=builder /usr/local/bin/backend /usr/local/bin/backend
 COPY --from=builder /usr/local/bin/testing-backend /usr/local/bin/testing-backend
+COPY --from=builder /usr/local/bin/http-test-server /usr/local/bin/http-test-server
 
 USER 10001
 


### PR DESCRIPTION
### Fixed

- added missing http-test-server executable to final stage of docker image
