### PR TITLE
mx-2133_add_sanity_check_to_migration_script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- workflow migration check: only process items which can't be validated as merged item
+
 ### Changes
 
 ### Deprecated

--- a/scripts/add_workflow_targets_for_switched_off_merged_items.py
+++ b/scripts/add_workflow_targets_for_switched_off_merged_items.py
@@ -1,6 +1,8 @@
 import click
 
 from mex.backend.graph.connector import GraphConnector
+from mex.backend.graph.exceptions import NoResultFoundError
+from mex.backend.merged.helpers import get_merged_item_from_graph
 from mex.backend.rules.helpers import get_rule_set_from_graph, update_and_get_rule_set
 from mex.common.fields import REQUIRED_FIELDS_BY_CLASS_NAME
 from mex.common.logging import logger
@@ -117,7 +119,15 @@ def get_all_rule_set_ids() -> list[str]:
         skip=0,
         limit=5000,
     )
-    return sorted({item["stableTargetId"][0] for item in graph_result.one()["items"]})
+
+    ids_merged_items_with_rules: set[str] = set()
+    for item in graph_result.one()["items"]:
+        stid = item["stableTargetId"][0]
+        try:
+            get_merged_item_from_graph(identifier=stid)
+        except NoResultFoundError:  # only process if item can't be validated
+            ids_merged_items_with_rules.add(stid)
+    return sorted(ids_merged_items_with_rules)
 
 
 def transform_rule_set_response_to_request(


### PR DESCRIPTION
### Added
- workflow migration check: only process items which can't be validated as merged item