### PR TITLE
MX-2206 no neo4j indices for preview models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changes
+- GraphConnector does not create index of PreviewModels anymore
 
 ### Deprecated
 

--- a/mex/backend/graph/connector.py
+++ b/mex/backend/graph/connector.py
@@ -44,6 +44,7 @@ from mex.common.logging import logger
 from mex.common.models import (
     EXTRACTED_MODEL_CLASSES_BY_NAME,
     MERGED_MODEL_CLASSES_BY_NAME,
+    PREVIEW_MODEL_CLASSES_BY_NAME,
     RULE_MODEL_CLASSES_BY_NAME,
     RULE_MODEL_CLASSES_BY_TYPE_BY_NAME,
     AnyExtractedModel,
@@ -117,12 +118,17 @@ class GraphConnector(BaseConnector):
     def _seed_indices(self) -> Result:
         """Ensure there is a full text search index for all searchable fields."""
         query_builder = QueryBuilder.get()
+        searchable_classes = [
+            label
+            for label in SEARCHABLE_CLASSES
+            if label not in PREVIEW_MODEL_CLASSES_BY_NAME
+        ]
         result = self.commit(
             query_builder.get_full_text_search_index(),
             access_mode=WRITE_ACCESS,
         )
         if (index := result.one_or_none()) and (
-            set(index["node_labels"]) != set(SEARCHABLE_CLASSES)
+            set(index["node_labels"]) != set(searchable_classes)
             or set(index["search_fields"]) != set(SEARCHABLE_FIELDS)
         ):
             # only drop the index if the classes or fields have changed
@@ -133,7 +139,7 @@ class GraphConnector(BaseConnector):
             logger.info("searchable fields changed: dropped indices")
         result = self.commit(
             query_builder.create_full_text_search_index(
-                node_labels=SEARCHABLE_CLASSES,
+                node_labels=searchable_classes,
                 search_fields=SEARCHABLE_FIELDS,
             ),
             access_mode=WRITE_ACCESS,

--- a/tests/graph/test_connector.py
+++ b/tests/graph/test_connector.py
@@ -156,6 +156,45 @@ def test_mocked_graph_seed_indices(
 
 
 @pytest.mark.usefixtures("mocked_query_class", "mocked_valkey")
+def test_seed_indices_excludes_preview_models(
+    mocked_graph: MockedGraph,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        connector_module,
+        "SEARCHABLE_CLASSES",
+        ["ExtractedThis", "PreviewThing", "ExtractedThat"],
+    )
+    monkeypatch.setattr(
+        connector_module,
+        "PREVIEW_MODEL_CLASSES_BY_NAME",
+        {"PreviewThing": object},
+    )
+    monkeypatch.setattr(
+        connector_module,
+        "SEARCHABLE_FIELDS",
+        ["title", "name"],
+    )
+
+    graph = GraphConnector.get()
+    graph._seed_indices()
+
+    assert mocked_graph.call_args_list[-1] == call(
+        call(
+            "create_full_text_search_index",
+            node_labels=["ExtractedThis", "ExtractedThat"],
+            search_fields=["title", "name"],
+        ),
+        {
+            "index_config": {
+                "fulltext.eventually_consistent": True,
+                "fulltext.analyzer": "german",
+            }
+        },
+    )
+
+
+@pytest.mark.usefixtures("mocked_query_class", "mocked_valkey")
 def test_mocked_graph_seed_data(mocked_graph: MockedGraph) -> None:
     mocked_graph.side_effect = [
         [


### PR DESCRIPTION
### Changes
- GraphConnector does not create index of PreviewModels anymore
